### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,15 @@ repos:
       - id: requirements-txt-fixer
       - id: mixed-line-ending
         args: [ '--fix=auto' ]
-  - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.9.0
+  - repo: https://github.com/Tesla2000/black-compatible-reorder-python-imports
+    rev: v0.0.1
     hooks:
       - id: reorder-python-imports
+        args:
+          [
+            --retain-pre-import,
+            'True',
+          ]
   - repo: https://github.com/myint/autoflake
     rev: v2.0.0
     hooks:


### PR DESCRIPTION
Hello,

I saw that you raised an issue regarding [reorder-python-imports](https://github.com/asottile/reorder-python-imports) not being compatible with the current version of Black [issue](https://github.com/asottile/reorder-python-imports/issues/388). Since the author has been unwilling to accept changes, I decided to publish a compatible version in the spirit of open source.

To ensure full compatibility, you’ll need to set the --retain-pre-import flag. Otherwise, it works exactly the same as the original implementation.